### PR TITLE
Make job status queries robust to ordering

### DIFF
--- a/benchmark/launch.sh
+++ b/benchmark/launch.sh
@@ -101,8 +101,8 @@ kubectl label ns "$SIMI_NAMESPACE" com.corsha.ecm.disruptible=false --overwrite
 sleep 5
 
 get_statuses() {
-  simi_status=$(kubectl -n "$SIMI_NAMESPACE" get jobs -o go-template --template='{{range .items}}{{if and ( eq .metadata.name "simi") ( .status.conditions) }}{{(index .status.conditions 0).type }}{{end}}{{ end }}')
-  consumer_status=$(kubectl -n "$SIMI_NAMESPACE" get jobs -o go-template --template='{{range .items}}{{if and (eq .metadata.name "consumer") ( .status.conditions) }}{{(index .status.conditions 0).type }}{{end}}{{ end }}')
+  simi_status=$(kubectl -n "$SIMI_NAMESPACE" get jobs -o go-template --template='{{range .items}}{{if eq .metadata.name "simi"}}{{range .status.conditions}}{{if or (eq .type "Complete") (eq .type "Failed")}}{{.type}}{{"\n"}}{{end}}{{end}}{{end}}{{end}}')
+  consumer_status=$(kubectl -n "$SIMI_NAMESPACE" get jobs -o go-template --template='{{range .items}}{{if eq .metadata.name "consumer"}}{{range .status.conditions}}{{if or (eq .type "Complete") (eq .type "Failed")}}{{.type}}{{"\n"}}{{end}}{{end}}{{end}}{{end}}')
   echo -e "status:\n  consumer: $consumer_status\n  simi: $simi_status\n"
 }
 


### PR DESCRIPTION
Before you submit your PR, make sure you check each of the following:

1. [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and signed the [Contributor License Agreement](../CLA.md).
2. [x] My code is clean and ready-to-PR, including being free of lint errors and dead code
3. [x] I have **tested** my change / code and am confident that it works
4. [x] I have filled in the template below completely and accurately
##### Changelog

The queries that check for the job status assume the Running / Succeeded/ Failed status always appeared in the 0th index, but this is not true. The result is that the script would run forever.

This modifies the script to check any of the condition indicies to see if they match.

##### Testing

Run `./benchmark/launch.sh` and verify script exits and saves results when jobs complete. Additionally, modified the simi jobs to end at a random time and verified it waits for all to complete.

##### Unit Tests

NA
